### PR TITLE
chore(docker): remove obsolote compose 'version' key

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   postgres:
     image: postgres:15


### PR DESCRIPTION
Elimina la clave obsoleta version para evitar el warning en Docker Compose